### PR TITLE
Fix similar apps function by replacing undici with native fetch

### DIFF
--- a/src/__tests__/similar.test.ts
+++ b/src/__tests__/similar.test.ts
@@ -4,7 +4,6 @@ import { similar } from '../lib/similar.js';
 describe('similar', () => {
   it('should throw error when neither id nor appId is provided', async () => {
     await expect(
-      // @ts-expect-error - testing invalid input
       similar({})
     ).rejects.toThrow('Either id or appId is required');
   });
@@ -23,7 +22,7 @@ describe('similar', () => {
       expect(results[0]).toHaveProperty('id');
       expect(results[0]).toHaveProperty('title');
       expect(results[0]).toHaveProperty('appId');
-      expect(results[0].id).not.toBe(842842640); // Should not include the original app
+      expect(results[0]?.id).not.toBe(842842640); // Should not include the original app
     }
   });
 

--- a/src/lib/privacy.ts
+++ b/src/lib/privacy.ts
@@ -1,4 +1,3 @@
-import type { Dispatcher } from 'undici';
 import type { PrivacyDetails } from '../types/review.js';
 import type { PrivacyOptions } from '../types/options.js';
 import { doRequest } from './common.js';
@@ -45,7 +44,7 @@ export async function privacy(options: PrivacyOptions): Promise<PrivacyDetails> 
       Authorization: `Bearer ${token}`,
       ...(requestOptions?.headers || {}),
     },
-  } as Dispatcher.RequestOptions);
+  });
 
   // Parse and validate response with Zod
   const parsedData = JSON.parse(ampBody) as unknown;

--- a/src/lib/ratings.ts
+++ b/src/lib/ratings.ts
@@ -1,4 +1,3 @@
-import type { Dispatcher } from 'undici';
 import * as cheerio from 'cheerio';
 import type { RatingHistogram } from '../types/app.js';
 import type { RatingsOptions } from '../types/options.js';
@@ -31,7 +30,7 @@ export async function ratings(options: RatingsOptions): Promise<RatingHistogram>
       'X-Apple-Store-Front': `${store},12`,
       ...(requestOptions?.headers || {}),
     },
-  } as Dispatcher.RequestOptions);
+  });
 
   const $ = cheerio.load(body);
 

--- a/src/lib/similar.ts
+++ b/src/lib/similar.ts
@@ -30,8 +30,8 @@ export async function similar(options: SimilarOptions): Promise<App[]> {
     throw new Error('Could not resolve app id');
   }
 
-  // Build URL for "Customers Also Bought Apps" page
-  const url = `https://apps.apple.com/${country}/app/app/id${id}?see-all=customers-also-bought-apps&platform=iphone`;
+  // Build URL for main app page (contains similar apps embedded in HTML)
+  const url = `https://apps.apple.com/${country}/app/id${id}`;
 
   let body: string;
   try {
@@ -51,7 +51,9 @@ export async function similar(options: SimilarOptions): Promise<App[]> {
   $('a[href*="/app/"]').each((_, element) => {
     const href = $(element).attr('href');
     if (href) {
-      // Extract ID from URL like "/fi/app/app-name/id123456"
+      // Extract ID from URLs like:
+      // "https://apps.apple.com/us/app/app-name/id123456"
+      // or "/fi/app/app-name/id123456"
       const match = href.match(/\/id(\d+)/);
       if (match && match[1]) {
         const appId = parseInt(match[1], 10);

--- a/src/lib/version-history.ts
+++ b/src/lib/version-history.ts
@@ -1,4 +1,3 @@
-import type { Dispatcher } from 'undici';
 import type { VersionHistory } from '../types/review.js';
 import type { VersionHistoryOptions } from '../types/options.js';
 import { doRequest } from './common.js';
@@ -45,7 +44,7 @@ export async function versionHistory(options: VersionHistoryOptions): Promise<Ve
       Authorization: `Bearer ${token}`,
       ...(requestOptions?.headers || {}),
     },
-  } as Dispatcher.RequestOptions);
+  });
 
   // Parse and validate response with Zod
   const parsedData = JSON.parse(ampBody) as unknown;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,5 +1,8 @@
-import type { Dispatcher } from 'undici';
 import type { Collection, Category, Sort } from './constants.js';
+
+export interface RequestOptions {
+  headers?: Record<string, string>;
+}
 
 /**
  * Common options for requests
@@ -9,8 +12,8 @@ export interface BaseOptions {
   country?: string;
   /** Language code (e.g., "en-us") */
   lang?: string;
-  /** Custom request options for undici */
-  requestOptions?: Dispatcher.RequestOptions;
+  /** Custom request options */
+  requestOptions?: RequestOptions;
   /** Rate limit (requests per interval) */
   throttle?: number;
 }


### PR DESCRIPTION
The similar() function was returning 0 results due to several issues with the HTTP request implementation using undici:

1. Apple's servers return 301 redirects for app pages
2. undici's request() API doesn't follow redirects by default
3. Apple's servers block requests without proper browser headers

Changes made:

- Replace undici's request() with native fetch() which follows redirects automatically
- Add proper browser headers (User-Agent, Accept, Accept-Language) to doRequest()
- Update similar() to scrape main app page instead of see-all page
- Replace Dispatcher.RequestOptions type with custom RequestOptions interface
- Export RequestOptions from types/options.ts for consistency

The similar function now successfully returns 20+ similar apps by:
- Scraping app page HTML with cheerio
- Extracting app IDs from links matching /app/.*/id\d+
- Filtering duplicates and the original app
- Fetching full details via iTunes lookup API

All tests pass and the function returns expected results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)