### PR TITLE
Rename package to @perttu/app-store-scraper

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,4 +1,4 @@
-# app-store-scraper-ts Implementation Summary
+# @perttu/app-store-scraper Implementation Summary
 
 ## Overview
 
@@ -176,7 +176,7 @@ dist/
 ## File Structure
 
 ```
-app-store-scraper-ts/
+@perttu/app-store-scraper/
 ├── src/
 │   ├── types/              # TypeScript type definitions
 │   │   ├── app.ts          # App & RatingHistogram types
@@ -211,7 +211,7 @@ app-store-scraper-ts/
 ## Usage Example
 
 ```typescript
-import { app, search, collection, category } from 'app-store-scraper-ts';
+import { app, search, collection, category } from '@perttu/app-store-scraper';
 
 // Get app details
 const appData = await app({ id: 553834731 });
@@ -252,7 +252,7 @@ const store = require('app-store-scraper');
 store.app({ id: 123 }).then(console.log);
 
 // New (TypeScript)
-import { app } from 'app-store-scraper-ts';
+import { app } from '@perttu/app-store-scraper';
 const data = await app({ id: 123 });
 console.log(data);
 ```

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This is a complete TypeScript rewrite of [facundoolano/app-store-scraper](https:
 ## Installation
 
 ```bash
-npm install app-store-scraper-ts
+npm install @perttu/app-store-scraper
 ```
 
 ## Usage
 
 ```typescript
-import { app, search, list, reviews, collection, category } from 'app-store-scraper-ts';
+import { app, search, list, reviews, collection, category } from '@perttu/app-store-scraper';
 
 // Get app details
 const appData = await app({ id: 553834731 });

--- a/examples/all-methods.ts
+++ b/examples/all-methods.ts
@@ -1,5 +1,5 @@
 /**
- * Comprehensive test of all app-store-scraper-ts methods
+ * Comprehensive test of all @perttu/app-store-scraper methods
  * Run with: npx tsx examples/all-methods.ts
  */
 
@@ -32,7 +32,7 @@ const TEST_BUNDLE_ID = 'com.midasplayer.apps.candycrushsaga';
 const line = '-'.repeat(60);
 
 async function testAllMethods() {
-  console.log('🧪 Testing all app-store-scraper-ts methods\n');
+  console.log('🧪 Testing all @perttu/app-store-scraper methods\n');
   console.log(line);
 
   try {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-store-scraper-ts",
+  "name": "@perttu/app-store-scraper",
   "version": "1.0.1",
   "description": "Modern TypeScript library to scrape application data from the iTunes/Mac App Store",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * app-store-scraper-ts
+ * @perttu/app-store-scraper
  * Modern TypeScript library to scrape application data from the iTunes/Mac App Store
  */
 


### PR DESCRIPTION
Updated package name from app-store-scraper-ts to @perttu/app-store-scraper across all files:
- package.json: Updated package name
- README.md: Updated installation and import instructions
- IMPLEMENTATION.md: Updated all references to new package name
- examples/all-methods.ts: Updated comments to reflect new name
- src/index.ts: Updated package description comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)