### PR TITLE
Release v2.0.0 - Major breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perttu/app-store-scraper",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Modern TypeScript library to scrape application data from the iTunes/Mac App Store",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/suggest.ts
+++ b/src/lib/suggest.ts
@@ -25,8 +25,6 @@ export async function suggest(options: SuggestOptions): Promise<Suggestion[]> {
   const url = `https://search.itunes.apple.com/WebObjects/MZSearchHints.woa/wa/hints?clientApplication=Software&term=${encodeURIComponent(term)}`;
 
   const body = await doRequest(url, requestOptions);
-  console.log('Response body length:', body.length);
-  console.log('Response body preview:', body.substring(0, 500));
 
   const parser = new XMLParser({
     ignoreAttributes: false,
@@ -34,33 +32,27 @@ export async function suggest(options: SuggestOptions): Promise<Suggestion[]> {
   });
 
   const parsedData = parser.parse(body) as unknown;
-  console.log('Parsed data:', JSON.stringify(parsedData, null, 2));
 
   // Validate response with Zod
   const validationResult = suggestResponseSchema.safeParse(parsedData);
 
   if (!validationResult.success) {
-    console.log('Validation error:', validationResult.error.message);
     throw new Error(
       `Suggest API response validation failed: ${validationResult.error.message}`
     );
   }
 
   const result = validationResult.data;
-  console.log('Validated result:', JSON.stringify(result, null, 2));
 
   // Navigate the plist structure to extract suggestions
   const arrayData = result.plist?.dict?.array;
-  console.log('Array data:', JSON.stringify(arrayData, null, 2));
 
   // If array is a string or doesn't have dict, return empty
   if (!arrayData || typeof arrayData === 'string' || !arrayData.dict) {
-    console.log('No dict found in array data, returning empty');
     return [];
   }
 
   const dicts = arrayData.dict || [];
-  console.log('Dicts:', JSON.stringify(dicts, null, 2));
 
   const suggestions: Suggestion[] = [];
 
@@ -72,6 +64,5 @@ export async function suggest(options: SuggestOptions): Promise<Suggestion[]> {
     }
   }
 
-  console.log('Final suggestions:', suggestions);
   return suggestions;
 }


### PR DESCRIPTION
This release includes significant breaking changes due to Apple's App Store page structure changes that broke the bearer token extraction approach.

BREAKING CHANGES:
- ratings() now returns { ratings: number, histogram: RatingHistogram } instead of just RatingHistogram
- versionHistory() and privacy() completely rewritten to scrape HTML instead of using bearer token + API approach

Fixed Scraping Methods:
- ratings(): Fixed to scrape from customer-reviews page with correct selectors (.vote .total) and return new Ratings type with histogram
- versionHistory(): Rewritten to scrape version history directly from HTML dialog elements instead of using deprecated bearer token + API
- privacy(): Rewritten to scrape privacy data from HTML dialog elements instead of using bearer token + AMP API

Type System Updates:
- Added new Ratings type with ratings count and histogram
- Exported Ratings type from main index
- Updated app() function to use new ratings API

Dependencies & Documentation:
- Removed unused dependencies: p-memoize, p-throttle, undici
- Removed MemoizeOptions type (no longer needed)
- Updated README to link to blog post about rate limiting/memoization
- Updated examples to use new Ratings type
- Removed debug logging from suggest()

Technical Implementation:
All scraping methods now use Cheerio to parse HTML directly from app store pages, making them more resilient to Apple's API changes.